### PR TITLE
fix: #114 amplifyのlambdaのpythonのバージョンの設定の資料化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       "jqVersion": "jq-1.6"
     },
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.9.17"
+      "version": "3.10.13"
     },
     "./features/root": {},
     // custom feature

--- a/.devcontainer/features/root/post-create-command-test.py
+++ b/.devcontainer/features/root/post-create-command-test.py
@@ -20,4 +20,4 @@ def test_python_is_installed(host):
     cmd = host.run("python --version")
     version = cmd.stdout.split()[1]
     assert cmd.stdout.startswith("Python")
-    assert version.startswith("3.9.17")
+    assert version.startswith("3.10.13")


### PR DESCRIPTION
pythonバージョンを3.10.13にアップデート