### PR TITLE
fix: #137 目次から除外する設定を削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# 目次 {ignore=true}
+# 目次
 
 <!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=1 orderedList=false} -->
 
 <!-- code_chunk_output -->
 
+- [目次](#目次)
 - [関連テンプレートリポジトリの README インデックス](#関連テンプレートリポジトリの-readme-インデックス)
 - [GitHub におけるリポジトリ作成について](#github-におけるリポジトリ作成について)
 - [テンプレートリポジトリについて](#テンプレートリポジトリについて)

--- a/doc/readme/issue/usage.md
+++ b/doc/readme/issue/usage.md
@@ -1,9 +1,10 @@
-# 目次 {ignore=true}
+# 目次
 
 <!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=3 orderedList=false} -->
 
 <!-- code_chunk_output -->
 
+- [目次](#目次)
 - [Issue について](#issue-について)
   - [Fix - バグ修正](#fix---バグ修正)
   - [Fix - 非機能](#fix---非機能)


### PR DESCRIPTION
## 概要

{ignore=true}の表示がReadme上ではそのまま表示されてしまうため修正を元に戻します

## 関連 Issue

関連する Issue やタスクをリンクしてください

- Issue: #137 
- PR: #140 

## 実施内容

具体的な変更点や修正箇所をリストアップしてください

- 直下Readmeの#目次から{ignore=true}の記述を削除
- doc"Issueについて"の#目次から{ignore=true}の記述を削除

## その他

<img width="930" alt="image" src="https://github.com/ambient-lab/ambient-tmpl-root/assets/141118878/a37f23e6-2449-4403-9733-4e2e3dbb3263">