### PR TITLE
fix: #105 pr作成時に自動でautomerge設定

### DIFF
--- a/.github/workflows/auto-merge-on-pull-requests.yml
+++ b/.github/workflows/auto-merge-on-pull-requests.yml
@@ -1,0 +1,16 @@
+name: Auto Merge On Pull Requests
+
+on:
+  pull_request:
+    types:
+      - opend
+
+jobs:
+  auto-merge-on-pull-requests:
+    name: Auto Merge On Pull Requests
+    runs-on: ubuntu-latest
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --merge --auto "$PR_URL"


### PR DESCRIPTION
## 概要

プルリク作成時にEnable auto-mergeボタンを押すことを省略するためのアクションを追加する

## 関連 Issue

関連する Issue やタスクをリンクしてください

- Issue: #105 

## 実施内容

具体的な変更点や修正箇所をリストアップしてください

- auto-merge-on-pull-requests.ymlファイルの追加

## その他
こちらマージ後にテスト用のIssueとブランチを作って動作を確認します。