### PR TITLE
feat: #151 PR作成時に自動でteamが設定されるようにする

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# コードオーナーに設定したユーザーやチームは
+# Pull Request作成時に自動的でReviewersに設定されます。
+
+# 全てのファイルのコードオーナー
+* @Ambient-Lab/ambient-dev-private


### PR DESCRIPTION
## 概要

PR作成時に自動でteamが設定されるようコードオーナーを追加する

## 実施内容

- .github/CODEOWNERSの追加
  - 設定内容
    - 対象: 全て
    - owner: ambient-lab/ambient-dev-private 

## その他

このPRはまだコードオーナーによるレビュアー設定は有効になっていませんが、手動で ambient-dev-private を入れています。
ambient-dev-privateはteamの Auto Assign 機能を用いてPR作成後に個人宛へと転換されます。