### PR TITLE
fix: #171 Blank IssueがtemplateとGithub標準で2つ表示される

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## 概要

Issue templateで作成したBlank Issueと、Github標準のBlank Issueが表示される問題を修正する
<img width="755" alt="image" src="https://github.com/ambient-lab/ambient-tmpl-root/assets/141118878/eb3aba8a-dd28-4838-ae36-725a7684b599">


## 実施内容

具体的な変更点や修正箇所をリストアップしてください

- .github/ISSUE_TEMPLATE/config.ymlの追加
  - Github標準のBlank Issueを無効化
